### PR TITLE
fix some fonts fail to load

### DIFF
--- a/generators/generator_phantom.html
+++ b/generators/generator_phantom.html
@@ -63,14 +63,14 @@
 							active: function() {
 								// console.log('active');
 							},
-							fontactive: function(param) {
-								console.log('Loaded.... ' + param);
-								loadedFontsArray.push(param);
+							fontactive: function() {
+								console.log('Loaded.... ' + fonts[0]);
+								loadedFontsArray.push(fonts[0]);
 								checkIfAllFontsAreLoaded();
 							},
-							fontinactive: function(param) {
-								console.log('Not loaded.... ' + param);
-								notLoadedFontsArray.push(param);
+							fontinactive: function() {
+								console.log('Not loaded.... ' + fonts[0]);
+								notLoadedFontsArray.push(fonts[0]);
 								checkIfAllFontsAreLoaded();
 							}
 						});

--- a/generators/generator_phantom.html
+++ b/generators/generator_phantom.html
@@ -45,7 +45,7 @@
 					processLargeArrayAsync(data.items, function(item, index, array) {
 						console.log("Loading chunk: " + index);
 						$("#fonts").append("<li style='font-family:" + item.family + "'>" + item.family + "</li>");
-						const key = item.family + ':' + item.variants[0];
+						const key = item.family + ':' + findBestVariant(item);
 						familiesArray.push(key);
 						loadFonts([key]);
 					}, 100, window, function() {
@@ -92,6 +92,15 @@
 						}
 					}
 
+					function findBestVariant(font) {
+						var variants = font.variants;
+
+						if (variants.includes('regular')) {
+							return 'regular';
+						}
+
+						return variants[0];
+					}
 					function processLargeArrayAsync(array, fn, chunk, context, finishCallbck) {
 						context = context || window;
 						chunk = chunk || 100;

--- a/generators/generator_phantom.html
+++ b/generators/generator_phantom.html
@@ -38,14 +38,16 @@
 				$.get("https://www.googleapis.com/webfonts/v1/webfonts?key=<%= googleAPIKey %>", function(data) {
 					var familiesArray = [];
 					var loadedFontsArray = [];
+					var notLoadedFontsArray = [];
 					var loadingChunksFinished = false;
 
 
 					processLargeArrayAsync(data.items, function(item, index, array) {
 						console.log("Loading chunk: " + index);
 						$("#fonts").append("<li style='font-family:" + item.family + "'>" + item.family + "</li>");
-						familiesArray.push(item.family);
-						loadFonts([item.family]);
+						const key = item.family + ':' + item.variants[0];
+						familiesArray.push(key);
+						loadFonts([key]);
 					}, 100, window, function() {
 						console.log("fFnish loading chunks");
 						loadingChunksFinished = true;
@@ -68,7 +70,7 @@
 							},
 							fontinactive: function(param) {
 								console.log('Not loaded.... ' + param);
-								loadedFontsArray.push(param);
+								notLoadedFontsArray.push(param);
 								checkIfAllFontsAreLoaded();
 							}
 						});
@@ -78,8 +80,12 @@
 						if (!loadingChunksFinished) {
 							return;
 						}
-						if (loadedFontsArray.length === familiesArray.length) {
+						if (loadedFontsArray.length + notLoadedFontsArray.length === familiesArray.length) {
 							console.log('Number of handled fonts:' + loadedFontsArray.length);
+							console.log('Number of failed fonts:' + notLoadedFontsArray.length);
+							notLoadedFontsArray.forEach((v) => {
+								console.log('- ', v);
+							});
 							setTimeout(function () {
 								console.log('takeScreenshot');
 							}, 10000);

--- a/generators/generator_phantom.html
+++ b/generators/generator_phantom.html
@@ -45,7 +45,7 @@
 					processLargeArrayAsync(data.items, function(item, index, array) {
 						console.log("Loading chunk: " + index);
 						$("#fonts").append("<li style='font-family:" + item.family + "'>" + item.family + "</li>");
-						const key = item.family + ':' + findBestVariant(item);
+						var key = item.family + ':' + findBestVariant(item);
 						familiesArray.push(key);
 						loadFonts([key]);
 					}, 100, window, function() {


### PR DESCRIPTION
Following fonts do not have Regular variant, resulting request failure. Adding available variant explicitly solves it.

- [Buda](https://fonts.google.com/specimen/Buda)
- [Coda Caption](https://fonts.google.com/specimen/Coda+Caption)
- [Molle](https://fonts.google.com/specimen/Molle)
- [Open Sans Condensed](https://fonts.google.com/specimen/Open+Sans+Condensed)
- [Sunflower](https://fonts.google.com/specimen/Sunflower)
- [UnifrakturCook](https://fonts.google.com/specimen/UnifrakturCook)